### PR TITLE
Make the footer stick to the bottom of the screen when page isn't long enough

### DIFF
--- a/_scss/layout.scss
+++ b/_scss/layout.scss
@@ -1,0 +1,14 @@
+// Styling affecting the layout of site-wide elements (header, footer &c)
+
+html, body {
+  height: 100%
+}
+
+body {
+    display: flex;
+    flex-direction: column;
+}
+
+.content {
+    flex: 1;
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -3,13 +3,13 @@
 
 // NNT SCSS
   @import "mixins";
-  @import "nt_variables"; 
+  @import "nt_variables";
   @import "semantics";
 
 // Bootstrap
   // Import custom Bootstrap variables
   @import "bootstrap_variables";
-  
+
   // Import Bootstrap
   @import "bootstrap";
   // or Import Bootstrap Flex
@@ -20,4 +20,5 @@
   // @import "bootstrap-reboot";
 
 // Custom CSS
+  @import "layout";
   @import "nt_style";


### PR DESCRIPTION
Make the body use display flex as a column.
Make the content block expand to fill available space.

![image](https://user-images.githubusercontent.com/1690934/53690006-39f1a700-3d5a-11e9-9931-befa071cac9e.png)

 to

![image](https://user-images.githubusercontent.com/1690934/53690007-41b14b80-3d5a-11e9-965d-b9aab0a7352f.png)
